### PR TITLE
Remove abstract keyword from  RepositoryBase .

### DIFF
--- a/OngProject/Repositories/RepositoryBase.cs
+++ b/OngProject/Repositories/RepositoryBase.cs
@@ -8,7 +8,7 @@ using OngProject.Repositories.Interfaces;
 
 namespace OngProject.Repositories
 {
-    public abstract class RepositoryBase<T> : IRepositoryBase<T> where T : BaseEntity
+    public  class RepositoryBase<T> : IRepositoryBase<T> where T : BaseEntity
     {
         private readonly OngDbContext _dbContext;
 


### PR DESCRIPTION
Con respecto US-24  [ Users], se me hace este review:

Desde el controller nos conectamos con el business y de ahí al unit of work. Por otro lado, al usar repo genéricos, no hace falta crear un userRepository

Seria algo como: 
  public IRepositoryBase<User> UserRepository => _userRepository ?? new RepositoryBase<User>( _dbContext);


pero para role se acepto el PR con Repositorio especifico para ROLE y no contamos con un Repositorio concreto porque la base es abstracta

Para seguir la arquitectura propuesta seria : quitar el abstract a RepositoryBase y cambiar la referencia en UnitOfWork para role quedando :

UnitOfWork.cs
...
private readonly  IRepositoryBase<Role> _roleRepository; ...
public IRoleRepository RoleRepository =>  _roleRepository ?? new RepositoryBase<Role>(dbContext: _dbContext);