### PR TITLE
Adds AmazonS3 SDK and configures helper for image uploading

### DIFF
--- a/OngProject/Core/Helper/ImageStorageHelper.cs
+++ b/OngProject/Core/Helper/ImageStorageHelper.cs
@@ -21,13 +21,16 @@ namespace OngProject.Core.Helper
 
         public async Task<string> UploadImageAsync(FileStream imageFile)
         {
-            var fileName = imageFile.Name;
+            var fileName = imageFile.Name.Normalize().Trim().ToLower();
+
             var credentials = new BasicAWSCredentials(_credentialsConfig.AWSAccessKey, _credentialsConfig.AWSSecretKey);
+
             var regionEndpoint = new AmazonS3Config()
             {
                 //Todo: Complete when get the credentials
                 // RegionEndpoint = Amazon.RegionEndpoint
             };
+
             var uploadRequest = new TransferUtilityUploadRequest()
             {
                 InputStream = imageFile,

--- a/OngProject/Core/Helper/ImageStorageHelper.cs
+++ b/OngProject/Core/Helper/ImageStorageHelper.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.IO;
+using System.Threading.Tasks;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Transfer;
+using Microsoft.Extensions.Configuration;
+using OngProject.Core.Interfaces;
+using OngProject.Core.Models;
+
+namespace OngProject.Core.Helper
+{
+    public class ImageStorageHelper : IImageStorageHerlper
+    {
+        private readonly AWS3ConfigurationModel _credentialsConfig;
+
+        public ImageStorageHelper(AWS3ConfigurationModel credentialsConfig)
+        {
+            _credentialsConfig = credentialsConfig;
+        }
+
+        public async Task<string> UploadImageAsync(FileStream imageFile)
+        {
+            var fileName = imageFile.Name;
+            var credentials = new BasicAWSCredentials(_credentialsConfig.AWSAccessKey, _credentialsConfig.AWSSecretKey);
+            var regionEndpoint = new AmazonS3Config()
+            {
+                //Todo: Complete when get the credentials
+                // RegionEndpoint = Amazon.RegionEndpoint
+            };
+            var uploadRequest = new TransferUtilityUploadRequest()
+            {
+                InputStream = imageFile,
+                Key = fileName,
+                BucketName = _credentialsConfig.AWSBuctketName
+            };
+
+            using var amazonClient = new AmazonS3Client(credentials, regionEndpoint);
+
+            var transferUtility = new TransferUtility(amazonClient);
+
+            await transferUtility.UploadAsync(uploadRequest);
+
+            var absolutePath =
+                $"https://{_credentialsConfig.AWSBuctketName}.s3.{regionEndpoint}.amazonaws.com/{fileName}";
+
+            return absolutePath;
+
+        }
+    }
+}

--- a/OngProject/Core/Interfaces/IImageStorageHelper.cs
+++ b/OngProject/Core/Interfaces/IImageStorageHelper.cs
@@ -1,0 +1,10 @@
+﻿using System.IO;
+using System.Threading.Tasks;
+
+namespace OngProject.Core.Interfaces
+{
+    public interface IImageStorageHerlper
+    {
+        Task<string> UploadImageAsync(FileStream imageFile);
+    }
+}

--- a/OngProject/Core/Models/AWS3ConfigurationModel.cs
+++ b/OngProject/Core/Models/AWS3ConfigurationModel.cs
@@ -1,0 +1,13 @@
+﻿namespace OngProject.Core.Models
+{
+    public class AWS3ConfigurationModel
+    {
+        public const string AwsConfiguration  = "AwsConfiguration";
+
+        public string AWSAccessKey { get; set; }
+
+        public string AWSSecretKey { get; set; }
+
+        public string AWSBuctketName { get; set; }
+    }
+}

--- a/OngProject/OngProject.csproj
+++ b/OngProject/OngProject.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AWSSDK.S3" Version="3.7.9.53" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.17" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.17" />

--- a/OngProject/Startup.cs
+++ b/OngProject/Startup.cs
@@ -20,6 +20,7 @@ using OngProject.DataAccess;
 using OngProject.Repositories;
 using OngProject.Repositories.Interfaces;
 using Microsoft.EntityFrameworkCore;
+using OngProject.Core.Models;
 
 namespace OngProject
 {
@@ -61,6 +62,9 @@ namespace OngProject
                     };
                 }
             );
+            //Injects the configuration to the AWS3 helper
+            services.Configure<AWS3ConfigurationModel>(
+                Configuration.GetSection(AWS3ConfigurationModel.AwsConfiguration));
 
             ////agrego EF
             services.AddDbContext<OngDbContext>(options =>

--- a/OngProject/appsettings.json
+++ b/OngProject/appsettings.json
@@ -14,5 +14,10 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "ONG": "Server=(localdb)\\MSSQLLocalDB;Database=ONG;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "AwsConfiguration": {
+    "AWSAccessKey" : "",
+    "AWSSecretKey": "",
+    "AWSBucketName": ""
   }
 }


### PR DESCRIPTION
Se deberá vincular el servicio para manejo de archivos Amazon S3, a través de su SDK para .NET. El mismo se utilizará posteriormente para campos de diferentes entidades, como la foto de perfil del usuario, logo de ONG, imágenes del blog y demás, por lo que debe crearse un servicio reutilizable para el manejo de archivos.